### PR TITLE
Downgrade cypress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -664,9 +664,9 @@
       }
     },
     "commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -710,9 +710,9 @@
       }
     },
     "cypress": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.6.0.tgz",
-      "integrity": "sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.1.0.tgz",
+      "integrity": "sha512-craPRO+Viu4268s7eBvX5VJW8aBYcAQT+EwEccQSMY+eH1ZPwnxIgyDlmMWvxLVX9SkWxOlZbEycPyzanQScBQ==",
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
         "@cypress/request": "^2.88.5",
@@ -726,7 +726,7 @@
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-table3": "~0.6.0",
-        "commander": "^5.1.0",
+        "commander": "^4.1.1",
         "common-tags": "^1.8.0",
         "debug": "^4.1.1",
         "eventemitter2": "^6.4.2",
@@ -744,10 +744,10 @@
         "minimist": "^1.2.5",
         "moment": "^2.27.0",
         "ospath": "^1.2.2",
-        "pretty-bytes": "^5.4.1",
+        "pretty-bytes": "^5.3.0",
         "ramda": "~0.26.1",
         "request-progress": "^3.0.0",
-        "supports-color": "^7.2.0",
+        "supports-color": "^7.1.0",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
         "url": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "precommit": "npm run lint"
   },
   "dependencies": {
-    "cypress": "^5.6.0",
     "babel-eslint": "^10.0.2",
+    "cypress": "^5.1.0",
     "cypress-failed-log": "^2.5.0",
     "cypress-file-upload": "^4.1.1",
     "eslint": "^6.1.0",


### PR DESCRIPTION
Higher versions have a known bug which causes the GoCD run to fail

https://github.com/cypress-io/cypress/issues/5965#issuecomment-720513693