### PR TITLE
VAN-393: update failure message to match MFE

### DIFF
--- a/cypress/integration/authn_mfe/tests/test_forgot_password.spec.js
+++ b/cypress/integration/authn_mfe/tests/test_forgot_password.spec.js
@@ -12,7 +12,7 @@ describe('Forgot password page tests', function () {
   it('should show empty field error message', function () {
     forgotPasswordPage.clickSubmit()
     forgotPasswordPage.forgotPasswordFailureError().should('contain.text', 'Failed to send forgot password email.')
-    forgotPasswordPage.forgotPasswordFailureError().should('contain.text', 'Please enter your Email.')
+    forgotPasswordPage.forgotPasswordFailureError().should('contain.text', 'Please enter your email.')
   })
 
   it('should show invalid format error message', function () {
@@ -25,6 +25,6 @@ describe('Forgot password page tests', function () {
     const emailID = `${(Math.random() * 1e20).toString(36)}@example.com`
     forgotPasswordPage.sendForgotPasswordEmail(emailID)
     loginPage.forgotPasswordSuccessMessage().should('contain.text', emailID)
-    loginPage.forgotPasswordSuccessMessage().should('contain.text', 'Check Your Email')
+    loginPage.forgotPasswordSuccessMessage().should('contain.text', 'Check your email')
   })
 })

--- a/cypress/integration/authn_mfe/tests/test_login.spec.js
+++ b/cypress/integration/authn_mfe/tests/test_login.spec.js
@@ -14,8 +14,8 @@ describe('Login page tests', function () {
   it('should show empty field error messages', function () {
     loginPage.clickSubmit()
     loginPage.loginFailureError().should('contain.text', 'We couldn\'t sign you in.')
-    loginPage.loginFailureError().should('contain.text', 'Please enter your Email.')
-    loginPage.loginFailureError().should('contain.text', 'Please enter your Password.')
+    loginPage.loginFailureError().should('contain.text', 'Please enter your email.')
+    loginPage.loginFailureError().should('contain.text', 'Please enter your password.')
   })
 
   it('should show invalid email or password error message', function () {

--- a/cypress/integration/authn_mfe/tests/test_register.spec.js
+++ b/cypress/integration/authn_mfe/tests/test_register.spec.js
@@ -16,10 +16,10 @@ describe('Register page tests', function () {
   it('should show empty field error messages', function () {
     registerPage.clickSubmit()
     registerPage.registerFailureError().should('contain.text', 'We couldn\'t create your account.')
-    registerPage.registerFailureError().should('contain.text', 'Please enter your Full Name.')
-    registerPage.registerFailureError().should('contain.text', 'Please enter your Public Username.')
-    registerPage.registerFailureError().should('contain.text', 'Please enter your Email.')
-    registerPage.registerFailureError().should('contain.text', 'Please enter your Password.')
+    registerPage.registerFailureError().should('contain.text', 'Please enter your full name.')
+    registerPage.registerFailureError().should('contain.text', 'Please enter your public username.')
+    registerPage.registerFailureError().should('contain.text', 'Please enter your email.')
+    registerPage.registerFailureError().should('contain.text', 'Please enter your password.')
     registerPage.registerFailureError().should('contain.text', 'Select your country or region of residence.')
   })
 


### PR DESCRIPTION
Text in authn MFE  is now sentence cased, e2e tests need to be updated

Ticket: https://openedx.atlassian.net/browse/VAN-393