### PR TITLE
fix: preserve ecommerce tokens in test to avoid 401

### DIFF
--- a/cypress/integration/admin_portal/tests/test_bulk_code_management.spec.js
+++ b/cypress/integration/admin_portal/tests/test_bulk_code_management.spec.js
@@ -36,7 +36,7 @@ describe('bulk code management tests', function () {
   })
 
   beforeEach(function () {
-    Cypress.Cookies.preserveOnce('edxloggedin', 'stage-edx-user-info', 'stage-edx-sessionid')
+    Cypress.Cookies.preserveOnce('edxloggedin', 'stage-edx-user-info', 'stage-edx-sessionid', 'ecommerce_csrftoken', 'ecommerce_sessionid')
     cy.visit('/')
     landingPage.goToEnterprise(Cypress.env('enterprise_name'))
     landingPage.openCodeManagement()


### PR DESCRIPTION
Set values to be preserved so that ecommerce 401 does not happen on bulk code management tests.