### PR TITLE
fix: update method names

### DIFF
--- a/cypress/integration/authn_mfe/pages/forgot_password_page.js
+++ b/cypress/integration/authn_mfe/pages/forgot_password_page.js
@@ -8,11 +8,11 @@ class ForgotPasswordPage {
     cy.get('.btn-brand').click()
   }
 
-  forgotPasswordFailureError() {
+  getForgotPasswordFailureError() {
     return cy.get('.alert-danger')
   }
 
-  forgotPasswordSuccessMessage() {
+  getForgotPasswordSuccessMessage() {
     return cy.get('.alert-success')
   }
 }

--- a/cypress/integration/authn_mfe/pages/login_page.js
+++ b/cypress/integration/authn_mfe/pages/login_page.js
@@ -9,15 +9,15 @@ class LoginPage {
     cy.get('.btn-brand').click()
   }
 
-  dashboardMyCoursesHeader() {
+  getDashboardMyCoursesHeader() {
     return cy.get('.header-courses')
   }
 
-  welcomePageHeading() {
+  getWelcomePageHeading() {
     return cy.get('.welcome-page-heading')
   }
 
-  loginFailureError() {
+  getLoginFailureError() {
     return cy.get('#login-failure-alert')
   }
 }

--- a/cypress/integration/authn_mfe/pages/register_page.js
+++ b/cypress/integration/authn_mfe/pages/register_page.js
@@ -14,7 +14,7 @@ class RegisterPage {
     cy.get('.btn-brand').click()
   }
 
-  registerFailureError() {
+  getRegisterFailureError() {
     return cy.get('.alert-danger')
   }
 }

--- a/cypress/integration/authn_mfe/tests/test_forgot_password.spec.js
+++ b/cypress/integration/authn_mfe/tests/test_forgot_password.spec.js
@@ -9,20 +9,20 @@ describe('Forgot password page tests', function () {
 
   it('should show empty field error message', function () {
     forgotPasswordPage.clickSubmit()
-    forgotPasswordPage.forgotPasswordFailureError().should('contain.text', 'We were unable to contact you')
-    forgotPasswordPage.forgotPasswordFailureError().should('contain.text', 'Enter your email below')
+    forgotPasswordPage.getForgotPasswordFailureError().should('contain.text', 'We were unable to contact you')
+    forgotPasswordPage.getForgotPasswordFailureError().should('contain.text', 'Enter your email below')
   })
 
   it('should show invalid format error message', function () {
     forgotPasswordPage.sendForgotPasswordEmail('invalid')
-    forgotPasswordPage.forgotPasswordFailureError().should('contain.text', 'We were unable to contact you')
-    forgotPasswordPage.forgotPasswordFailureError().should('contain.text', 'Enter a valid email address below')
+    forgotPasswordPage.getForgotPasswordFailureError().should('contain.text', 'We were unable to contact you')
+    forgotPasswordPage.getForgotPasswordFailureError().should('contain.text', 'Enter a valid email address below')
   })
 
   it('user can see the success message on login page', function () {
     const emailID = `${(Math.random() * 1e20).toString(36)}@example.com`
     forgotPasswordPage.sendForgotPasswordEmail(emailID)
-    forgotPasswordPage.forgotPasswordSuccessMessage().should('contain.text', emailID)
-    forgotPasswordPage.forgotPasswordSuccessMessage().should('contain.text', 'Check your email')
+    forgotPasswordPage.getForgotPasswordSuccessMessage().should('contain.text', emailID)
+    forgotPasswordPage.getForgotPasswordSuccessMessage().should('contain.text', 'Check your email')
   })
 })

--- a/cypress/integration/authn_mfe/tests/test_login.spec.js
+++ b/cypress/integration/authn_mfe/tests/test_login.spec.js
@@ -13,18 +13,18 @@ describe('Login page tests', function () {
 
   it('should show empty field error messages', function () {
     loginPage.clickSubmit()
-    loginPage.loginFailureError().should('contain.text', 'We couldn\'t sign you in.')
-    loginPage.loginFailureError().should('contain.text', 'Please fill in the fields below.')
+    loginPage.getLoginFailureError().should('contain.text', 'We couldn\'t sign you in.')
+    loginPage.getLoginFailureError().should('contain.text', 'Please fill in the fields below.')
   })
 
   it('should show invalid email or password error message', function () {
     loginPage.loginUser('incorrect@email.com', 'incorrect-password')
-    loginPage.loginFailureError().should('contain.text', 'We couldn\'t sign you in.')
-    loginPage.loginFailureError().should('contain.text', 'The username, email, or password you entered is incorrect. Please try again.')
+    loginPage.getLoginFailureError().should('contain.text', 'We couldn\'t sign you in.')
+    loginPage.getLoginFailureError().should('contain.text', 'The username, email, or password you entered is incorrect. Please try again.')
   })
 
   it('user can successfully login and redirected to dashboard', function () {
     loginPage.loginUser(Cypress.env('ADMIN_USER_EMAIL'), Cypress.env('ADMIN_USER_PASSWORD'))
-    loginPage.dashboardMyCoursesHeader().should('have.text', 'My Courses')
+    loginPage.getDashboardMyCoursesHeader().should('have.text', 'My Courses')
   })
 })

--- a/cypress/integration/authn_mfe/tests/test_register.spec.js
+++ b/cypress/integration/authn_mfe/tests/test_register.spec.js
@@ -15,12 +15,12 @@ describe('Register page tests', function () {
 
   it('should show empty field error messages', function () {
     registerPage.clickSubmit()
-    registerPage.registerFailureError().should('contain.text', 'We couldn\'t create your account.')
-    registerPage.registerFailureError().should('contain.text', 'Please check your responses and try again.')
+    registerPage.getRegisterFailureError().should('contain.text', 'We couldn\'t create your account.')
+    registerPage.getRegisterFailureError().should('contain.text', 'Please check your responses and try again.')
   })
 
   it('user can successfully register and redirected to dashboard', function () {
     registerPage.registerNewUser()
-    loginPage.welcomePageHeading().should('have.text', 'A few questions for you will help us get smarter.')
+    loginPage.getWelcomePageHeading().should('have.text', 'A few questions for you will help us get smarter.')
   })
 })


### PR DESCRIPTION
As per investigations in the usage of cypress as an e2e test, it was found that a majority of the current test code was using method names that did not convey the meaning of functionality happening inside the method, which, according to [JS coding standards](https://google.github.io/styleguide/jsguide.html#naming-method-names), was not the best practice. A follow-up ticket was created to [update method names to be meaningful](https://openedx.atlassian.net/browse/PROD-2528?atlOrigin=eyJpIjoiODI4ZjM1ZGFkODNlNDM4YjgzMTFhMGJlN2M0ZDhkZDIiLCJwIjoiaiJ9). Here, I have addressed the following issues:

[PROD-2528](https://openedx.atlassian.net/browse/PROD-2528?atlOrigin=eyJpIjoiODI4ZjM1ZGFkODNlNDM4YjgzMTFhMGJlN2M0ZDhkZDIiLCJwIjoiaiJ9)

- [X] update method names to be meaningful

All of the tests edited were tested on the staging environment.